### PR TITLE
fix: prevent calculating sizes in all day events (week view)

### DIFF
--- a/components/views/Week.vue
+++ b/components/views/Week.vue
@@ -29,6 +29,7 @@
                         v-for="event, index in day.events.filter(e => !e.startTime)"
                         :key="index"
                         :event="event"
+                        :has-dynamic-size="false"
                         :use12="use12">
                 </event-item>
 


### PR DESCRIPTION
This PR fixes a bug on all day events in Week view (events size are evaluated but it shouldn't).