### PR TITLE
Locale-friendly week calendar

### DIFF
--- a/components/views/Week.vue
+++ b/components/views/Week.vue
@@ -91,7 +91,7 @@
 
                 let now = moment();
 
-                let temp = moment( this.activeDate ).day(0);
+                let temp = moment( this.activeDate ).day(moment.localeData().firstDayOfWeek());
                 let w = temp.week();
 
                 this.days = [];


### PR DESCRIPTION
This PR solves a bug when a moment locale is set but the first day of week is monday, e.g:
```js
Vue.use(VueScheduler, { locale:'fr' })
```
Currently, the calendar only display sunday in that case.
https://codesandbox.io/s/421m8j9pz9
