### PR TITLE
Set weekdaysShort to true

### DIFF
--- a/components/views/Month.vue
+++ b/components/views/Month.vue
@@ -42,7 +42,7 @@
         components: { EventItem },
         data() {
             return {
-                weekdays: moment.weekdaysShort(),
+                weekdays: moment.weekdaysShort(true),
                 calendar: [],
             }
         },


### PR DESCRIPTION
Set weekdaysShort to true so it would take weekdays from set locale

Quote from documentation: 

> As of 2.13.0 you can pass a bool as the first parameter of the weekday functions. If true, the weekdays will be returned in locale specific order. For instance, in the Arabic locale, Saturday is the first day of the week